### PR TITLE
refactor: rename Giscus component to GiscusComments and enhance theming support

### DIFF
--- a/src/components/BlogPost.tsx
+++ b/src/components/BlogPost.tsx
@@ -7,7 +7,7 @@ import rehypeHighlight from 'rehype-highlight';
 import rehypeRaw from 'rehype-raw';
 import type { BlogPost as BlogPostType } from '../types/blog';
 import { formatDate } from '../utils/blog';
-import Giscus from './Giscus';
+import GiscusComments from './Giscus';
 
 interface BlogPostProps {
   post: BlogPostType;
@@ -211,7 +211,7 @@ export default function BlogPost({ post }: BlogPostProps) {
 
       {/* Comments Section */}
       <div className="mt-12">
-        <Giscus />
+        <GiscusComments term={post.slug} />
       </div>
     </article>
   );

--- a/src/components/Giscus.tsx
+++ b/src/components/Giscus.tsx
@@ -1,14 +1,17 @@
 import Giscus from '@giscus/react';
+import { useTheme } from '../contexts/ThemeContext';
 
 interface GiscusCommentsProps {
   term?: string; // Used for mapping discussions to pages
 }
 
 export default function GiscusComments({ term }: GiscusCommentsProps) {
+  const { theme } = useTheme();
+
   return (
-    <div className="mt-12 pt-8 border-t border-gray-200">
+    <div className="mt-12 pt-8 border-t border-gray-200 dark:border-gray-700">
       <div className="max-w-4xl mx-auto">
-        <h3 className="text-2xl font-semibold text-gray-900 mb-6">Comments</h3>
+        <h3 className="text-2xl font-semibold text-gray-900 dark:text-gray-100 mb-6">Comments</h3>
         <Giscus
           id="comments"
           repo="DontFretBrett/portfolio"
@@ -16,11 +19,11 @@ export default function GiscusComments({ term }: GiscusCommentsProps) {
           category="General"
           categoryId="DIC_kwDONRd13c4CsWUg"
           mapping="specific"
-          term={term}
+          term={term || 'default'}
           reactionsEnabled="1"
           emitMetadata="0"
           inputPosition="top"
-          theme="light"
+          theme={theme}
           lang="en"
           loading="lazy"
         />


### PR DESCRIPTION
# Fix Blog Comment System - Giscus Integration Issues

## 🐛 Problem
The blog comment system was not functioning due to several integration issues with the Giscus component:
- Comments section was not rendering on blog posts
- Theme switching was not working (always showing light theme)
- Missing proper mapping between blog posts and comment threads

## 🔧 Solution
Fixed multiple issues in the Giscus comment system integration:

### 1. Component Import/Export Mismatch
- **Issue**: `BlogPost.tsx` was importing `Giscus` but component was exported as `GiscusComments`
- **Fix**: Updated import and usage to use correct component name

### 2. Missing Term Prop for Comment Mapping
- **Issue**: No `term` prop was being passed, preventing proper mapping of comments to specific blog posts
- **Fix**: Pass `post.slug` as term to create unique comment threads per blog post

### 3. Theme Integration
- **Issue**: Giscus was hardcoded to "light" theme, ignoring site's dark mode
- **Fix**: Integrated with existing `ThemeContext` to dynamically switch themes

### 4. Dark Mode Styling
- **Issue**: Comment section styling didn't support dark mode
- **Fix**: Added dark mode classes for borders and text

## 📁 Files Changed
- `src/components/BlogPost.tsx` - Fixed import and added term prop
- `src/components/Giscus.tsx` - Added theme integration and dark mode support

## 🧪 Testing
1. Navigate to any blog post (e.g., `/blog/welcome-to-my-blog`)
2. Scroll to bottom - comment section should now be visible
3. Toggle dark/light mode - comments should respect current theme
4. Each blog post should have its own separate comment thread

## ✅ Verification
- [ ] Comments section renders on blog posts
- [ ] Theme switching works correctly (light/dark)
- [ ] Each blog post has unique comment thread
- [ ] No TypeScript errors
- [ ] No console errors

## 📋 Additional Notes
- Comments are powered by GitHub Discussions in the `DontFretBrett/portfolio` repository
- Users will need GitHub accounts to leave comments
- Comment threads are mapped using blog post slugs for consistency

---

Fixes the blog comment system that was not displaying due to component integration issues.

## Summary by Sourcery

Refactor Giscus integration by renaming the component, restoring comment rendering with proper term mapping, and adding dynamic theming and dark mode styles

Bug Fixes:
- Restore comment section rendering and unique thread mapping by correcting the component import and passing post.slug as the term prop

Enhancements:
- Rename Giscus component to GiscusComments across imports and exports
- Integrate ThemeContext to apply the current site theme to the comments widget
- Add dark mode border and text classes for the comment container and heading