### PR TITLE
Fix margin and padding above certifications

### DIFF
--- a/src/index.css
+++ b/src/index.css
@@ -22,7 +22,6 @@
 /* Content Visibility for Performance */
 .below-fold-section {
   content-visibility: auto;
-  contain-intrinsic-size: auto 300px;
 }
 
 /* Modern Focus Management - WCAG 2.2 Compliance */

--- a/src/index.css
+++ b/src/index.css
@@ -19,10 +19,7 @@
   }
 }
 
-/* Content Visibility for Performance */
-.below-fold-section {
-  content-visibility: auto;
-}
+
 
 /* Modern Focus Management - WCAG 2.2 Compliance */
 .focus-visible {

--- a/src/pages/HomePage.tsx
+++ b/src/pages/HomePage.tsx
@@ -10,7 +10,7 @@ const Certifications = lazy(() => import('../components/Certifications'));
 // Enhanced loading component with better UX
 function ComponentLoader({ message = "Loading..." }: { message?: string }) {
   return (
-    <section className="p-16 text-center bg-gray-50 dark:bg-gray-900">
+    <section className="py-16 text-center bg-gray-50 dark:bg-gray-900">
       <div className="animate-spin rounded-full h-8 w-8 border-b-2 border-blue-600 dark:border-blue-400 mx-auto"></div>
       <p className="mt-4 text-gray-600 dark:text-gray-400">{message}</p>
     </section>
@@ -206,14 +206,12 @@ export default function HomePage() {
         <Skills />
         
         {/* Below-the-fold content with performance optimization */}
-        <div className="below-fold-section">
-          <Suspense fallback={<ComponentLoader message="Loading certifications..." />}>
-            <Certifications />
-          </Suspense>
-          <Suspense fallback={<ComponentLoader message="Loading experience..." />}>
-            <Experience />
-          </Suspense>
-        </div>
+        <Suspense fallback={<ComponentLoader message="Loading certifications..." />}>
+          <Certifications />
+        </Suspense>
+        <Suspense fallback={<ComponentLoader message="Loading experience..." />}>
+          <Experience />
+        </Suspense>
       </main>
     </>
   );


### PR DESCRIPTION
Remove `contain-intrinsic-size` from `.below-fold-section` to fix inconsistent spacing above Certifications & Training.

## Summary by Sourcery

Bug Fixes:
- Remove contain-intrinsic-size from .below-fold-section to fix inconsistent vertical spacing above Certifications & Training.