### PR TITLE
Add new music videos to musicData.ts

### DIFF
--- a/src/data/musicData.ts
+++ b/src/data/musicData.ts
@@ -12,6 +12,26 @@ export interface MusicVideo {
 
 export const musicVideos: MusicVideo[] = [
   {
+    id: "video-5",
+    title: "My Vices (Unplugged)",
+    description: "An intimate acoustic arrangement featuring creative AI-generated visual storytelling and cinematography.",
+    youtubeId: "tGBDga2NGko",
+    publishedDate: "2025-08-04",
+    tags: ["Indie", "Alternative", "Acoustic"],
+    genre: "Indie",
+    duration: "3:28"
+  },
+  {
+    id: "video-6",
+    title: "Right Now",
+    description: "An electronic track brought to life through innovative AI-powered video creation and visual effects.",
+    youtubeId: "KTHqBUERSvk",
+    publishedDate: "2025-08-04",
+    tags: ["Electronic"],
+    genre: "Electronic",
+    duration: "3:15"
+  },
+  {
     id: "video-1",
     title: "Nothing Ever Changes",
     description: "An experimental electronic track presented through an AI-generated music video.",


### PR DESCRIPTION
- Introduced two new music videos: "My Vices (Unplugged)" and "Right Now".
- Each video includes details such as title, description, YouTube ID, published date, tags, genre, and duration.
- Enhances the music video collection for a richer user experience.

## Summary by Sourcery

Add two new music video entries to the musicVideos collection for an enhanced user experience

New Features:
- Add 'My Vices (Unplugged)' music video entry with metadata
- Add 'Right Now' music video entry with metadata