### PR TITLE
feat(musicData): add new electronic music videos with descriptions and metadata

### DIFF
--- a/src/data/musicData.ts
+++ b/src/data/musicData.ts
@@ -72,6 +72,15 @@ export const musicVideos: MusicVideo[] = [
     duration: "3:14"
   },
   {
+    id: "video-7",
+    title: "Horizon Sequence (Instrumental)",
+    description: "An electronic instrumental track presented through an AI-generated music video.",
+    youtubeId: "YL3gm4QToo4",
+    publishedDate: "2025-09-17",
+    tags: ["Electronic"],
+    genre: "Electronic"
+  },
+  {
     id: "video-6",
     title: "Right Now",
     description: "A pop track brought to life through innovative AI-powered video creation and visual effects.",
@@ -80,15 +89,6 @@ export const musicVideos: MusicVideo[] = [
     tags: ["Pop"],
     genre: "Pop",
     duration: "3:15"
-  },
-  {
-    id: "video-7",
-    title: "Horizon Sequence (Instrumental)",
-    description: "An electronic instrumental track presented through an AI-generated music video.",
-    youtubeId: "YL3gm4QToo4",
-    publishedDate: "2025-09-17",
-    tags: ["Electronic"],
-    genre: "Electronic"
   },
   {
     id: "video-1",


### PR DESCRIPTION
<!-- CURSOR_SUMMARY -->
> [!NOTE]
> Adds videos 9–13 with full metadata and reorders the list to include video-7 earlier.
> 
> - **Data (`src/data/musicData.ts`)**:
>   - **Add MusicVideo entries**: `video-9`–`video-13` with titles, descriptions, `youtubeId`, dates, tags, genres, and durations.
>   - **Ordering adjustment**: Repositions `video-7` before `video-6` within `musicVideos`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit edd1b19d7fb8efdd430b6b9ed326dff4700e13c8. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

New Features:
- Add five electronic MusicVideo entries (video-9 to video-13) with descriptions, YouTube IDs, published dates, tags, genres, and durations