### PR TITLE
feat: add AI Questionnaire project

### DIFF
--- a/src/data/aiProjects.ts
+++ b/src/data/aiProjects.ts
@@ -246,7 +246,7 @@ This project demonstrates modern full-stack development with edge computing, ser
     excerpt: 'Bridge the context gap between humans and AI. This tool helps you document your work, values, and life details in an AI-ready format while keeping 100% of your data on your own device.',
     date: '2026-01-30',
     tags: ['React 19', 'Vite', 'Tailwind CSS 4', 'Framer Motion', 'shadcn/ui', 'AI Context', 'Privacy-First', 'Local Storage'],
-    githubUrl: 'https://github.com/DontFretBrett/ai-assistant-human-questionairre',
+    githubUrl: 'https://github.com/DontFretBrett/ai-assistant-human-questionnaire',
     liveUrl: 'https://ai-assistant-human-questionnaire.vercel.app',
     content: `# AI Assistant Human Questionnaire
 


### PR DESCRIPTION
Adds the AI Assistant Human Questionnaire project to the AI projects data, including a full write-up and embedded demo.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Data-only change adding a new catalog entry; no runtime logic or security-sensitive code paths are modified.
> 
> **Overview**
> Adds a new entry to `src/data/aiProjects.ts` for `ai-assistant-human-questionnaire`, including metadata (date, tags), GitHub/live links, and a long-form Markdown `content` description for rendering on the site.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit d625c777737218828d60f04a9c34f5a78732ea08. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

## Summary by Sourcery

Add a new AI Assistant Human Questionnaire project entry to the AI projects catalog with full descriptive content and embedded live demo.

New Features:
- Introduce the AI Assistant Human Questionnaire project as a privacy-first, browser-local questionnaire for building human profiles for AI assistants in the AI projects data.

Enhancements:
- Update documentation text for the monitor-neon-usage script description in the AI projects listing to reflect its current role.

Documentation:
- Document the AI Assistant Human Questionnaire project, including goals, privacy model, features, tech stack, and usage context, for display in the site.