### PR TITLE
feat: make resume infographic clickable to expand full size

### DIFF
--- a/src/pages/ResumePage.tsx
+++ b/src/pages/ResumePage.tsx
@@ -436,12 +436,25 @@ const selfStudyTopics = [
 // ─── Component ────────────────────────────────────────────────────────────────
 export default function ResumePage() {
   const [infographicOpen, setInfographicOpen] = useState(false);
+  const triggerRef = useRef<HTMLButtonElement>(null);
+  const closeBtnRef = useRef<HTMLButtonElement>(null);
 
   useEffect(() => {
     if (!infographicOpen) return;
+    // Lock body scroll
+    const prevOverflow = document.body.style.overflow;
+    document.body.style.overflow = 'hidden';
+    // Move focus into dialog
+    closeBtnRef.current?.focus();
+    // Escape key to close
     const onKey = (e: KeyboardEvent) => { if (e.key === 'Escape') setInfographicOpen(false); };
     document.addEventListener('keydown', onKey);
-    return () => document.removeEventListener('keydown', onKey);
+    return () => {
+      document.body.style.overflow = prevOverflow;
+      document.removeEventListener('keydown', onKey);
+      // Restore focus to trigger
+      triggerRef.current?.focus();
+    };
   }, [infographicOpen]);
 
   return (
@@ -564,24 +577,15 @@ export default function ResumePage() {
         {/* ── Infographic ──────────────────────────────────────────────────── */}
         <section className="container mx-auto px-4 pb-16 max-w-6xl">
           <SectionHeader icon={<Award size={20} />} title="At a Glance" />
-          <motion.div
+          <motion.button
+            ref={triggerRef}
             initial={{ opacity: 0, y: 20 }}
             whileInView={{ opacity: 1, y: 0 }}
             viewport={{ once: true }}
             transition={{ duration: 0.5 }}
-            className="relative group rounded-2xl overflow-hidden border border-gray-800 shadow-2xl shadow-black/40 cursor-zoom-in"
+            className="relative group w-full rounded-2xl overflow-hidden border border-gray-800 shadow-2xl shadow-black/40 cursor-zoom-in text-left"
             onClick={() => setInfographicOpen(true)}
-            role="button"
-            tabIndex={0}
             aria-label="View infographic full size"
-            onKeyDown={(e) => {
-              if (e.key === 'Enter' || e.key === ' ') {
-                if (e.key === ' ') {
-                  e.preventDefault();
-                }
-                setInfographicOpen(true);
-              }
-            }}
           >
             <img
               src="/infographic.png"
@@ -598,7 +602,7 @@ export default function ResumePage() {
                 Click to expand
               </div>
             </div>
-          </motion.div>
+          </motion.button>
         </section>
 
         {/* ── Infographic Lightbox ──────────────────────────────────────────── */}
@@ -616,6 +620,7 @@ export default function ResumePage() {
               aria-label="Infographic full size view"
             >
               <button
+                ref={closeBtnRef}
                 className="absolute top-4 right-4 text-white bg-white/10 hover:bg-white/20 rounded-full p-2 transition-colors"
                 onClick={() => setInfographicOpen(false)}
                 aria-label="Close"


### PR DESCRIPTION
Adds a lightbox modal to the "At a Glance" infographic section on the resume page. Clicking the image opens a full-viewport overlay with a smooth fade+scale animation. Supports keyboard (Escape to close, Enter/Space to open), click-outside to dismiss, and shows a hover hint with ZoomIn icon.

https://claude.ai/code/session_01TtrAAduP8xbjKK3N6kC7TT

## Summary by Sourcery

Add a clickable lightbox modal for the resume infographic with full-screen viewing and smooth animations.

New Features:
- Make the resume infographic act as an accessible button that opens a full-viewport overlay of the image.
- Add a hover hint with zoom icon on the infographic to indicate click-to-expand behavior.
- Introduce a full-screen lightbox with fade/scale animation, close button, and click-outside to dismiss for the infographic.

Enhancements:
- Support keyboard interactions for the infographic lightbox, including Enter/Space to open and Escape to close.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Primarily a UI/UX enhancement limited to `ResumePage`, with minor risk around modal focus/scroll locking and global Escape handling.
> 
> **Overview**
> Makes the “At a Glance” resume infographic interactive by turning it into a `motion.button` with a hover affordance and click-to-expand behavior.
> 
> Adds an animated full-viewport lightbox (`AnimatePresence`) that shows the infographic at full size, supports click-outside and *Escape* to close, locks background scroll while open, and manages focus by moving it to the close button and restoring it to the trigger on close.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 386058c32a6252ba3c118b1b9af1a9b5b8df075a. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->